### PR TITLE
JSON.sh depends on bash but has no shebang comment.

### DIFF
--- a/JSON.sh
+++ b/JSON.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 throw () {
   echo "$*" >&2


### PR DESCRIPTION
JSON.sh depends on bash but has no shebang comment.

Ensure that bash is used:
Where the location of bash can differ from one system to another system:
/bin/bash /usr/bin/bash /usr/local/bin/bash /opt/bin/bash etc

All systems (that I know of) have the env command in the same location
/usr/bin/env
