### PR TITLE
use gawk to extract token when egrep has no -o option

### DIFF
--- a/JSON.sh
+++ b/JSON.sh
@@ -61,26 +61,33 @@ awk_egrep () {
 }
 
 tokenize () {
-  local GREP='egrep -ao --color=never'
-  local ESCAPE='(\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
-  local CHAR='[^[:cntrl:]"\\]'
+  local GREP
+  local ESCAPE
+  local CHAR
 
-  echo "test string" | $GREP "test" &>/dev/null ||
-  GREP='egrep -ao'
+  if echo "test string" | egrep -ao --color=never "test" &>/dev/null
+  then
+    GREP='egrep -ao --color=never'
+  else
+    GREP='egrep -ao'
+  fi
 
-  echo "test string" | egrep -o "test" &>/dev/null ||
-  {
+  if echo "test string" | egrep -o "test" &>/dev/null
+  then
+    ESCAPE='(\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
+    CHAR='[^[:cntrl:]"\\]'
+  else
     GREP=awk_egrep
     ESCAPE='(\\\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
     CHAR='[^[:cntrl:]"\\\\]'
-  }
+  fi
 
   local STRING="\"$CHAR*($ESCAPE$CHAR*)*\""
   local NUMBER='-?(0|[1-9][0-9]*)([.][0-9]*)?([eE][+-]?[0-9]*)?'
   local KEYWORD='null|false|true'
   local SPACE='[[:space:]]+'
-  
-  $GREP "$STRING|$NUMBER|$KEYWORD|$SPACE|."
+
+  $GREP "$STRING|$NUMBER|$KEYWORD|$SPACE|." | egrep -v "^$SPACE$"
 }
 
 parse_array () {


### PR DESCRIPTION
Some version of egrep has no -o (--only-matching) option, so use gawk instead.

I found the issue when using JSON.sh in MSYS and Git Bash console (installed via msys-git) on Windows. The version of egrep on that platform is 2.4.2 which seems too old. I think many people like me do not like to pay extra effort to search and download the newer version of egrep to get the script to work. I just want to simply drag the JSON.sh scrip to my folder and start using it.
