### PR TITLE
Added possibility to remove solidus symbol escaping

### DIFF
--- a/JSON.sh
+++ b/JSON.sh
@@ -8,14 +8,16 @@ throw () {
 BRIEF=0
 LEAFONLY=0
 PRUNE=0
+NORMALIZE_SOLIDUS=0
 
 usage() {
   echo
-  echo "Usage: JSON.sh [-b] [-l] [-p] [-h]"
+  echo "Usage: JSON.sh [-b] [-l] [-p] [-s] [-h]"
   echo
   echo "-p - Prune empty. Exclude fields with empty values."
   echo "-l - Leaf only. Only show leaf nodes, which stops data duplication."
   echo "-b - Brief. Combines 'Leaf only' and 'Prune empty' options."
+  echo "-s - Remove escaping of the solidus symbol (stright slash)."
   echo "-h - This help text."
   echo
 }
@@ -36,6 +38,8 @@ parse_options() {
       -l) LEAFONLY=1
       ;;
       -p) PRUNE=1
+      ;;
+      -s) NORMALIZE_SOLIDUS=1
       ;;
       ?*) echo "ERROR: Unknown option."
           usage
@@ -159,6 +163,8 @@ parse_value () {
     # At this point, the only valid single-character tokens are digits.
     ''|[!0-9]) throw "EXPECTED value GOT ${token:-EOF}" ;;
     *) value=$token
+       # if asked, replace solidus ("\/") in json strings with normalized value: "/"
+       [ "$NORMALIZE_SOLIDUS" -eq 1 ] && value=${value//\\\//\/}
        isleaf=1
        [ "$value" = '""' ] && isempty=1
        ;;

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ curl registry.npmjs.org/express | ./JSON.sh | egrep '\["versions","[^"]*"\]'
 -p
 > Prune empty. Exclude fields with empty values.
 
+-s
+> Remove escaping of the solidus symbol (stright slash).
+
 -h
 > Show help text.
 

--- a/test/solidus-test.sh
+++ b/test/solidus-test.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+
+cd ${0%/*}
+
+INPUT=./solidus/string_with_solidus.json
+OUTPUT_ESCAPED=./solidus/string_with_solidus.with-escaping.parsed
+OUTPUT_WITHOUT_ESCAPING=./solidus/string_with_solidus.no-escaping.parsed
+
+FAILS=0
+
+echo "1..2"
+
+if ! ../JSON.sh < $INPUT| diff -u - ${OUTPUT_ESCAPED}; then
+  echo "not ok - JSON.sh run without -s option should leave solidus escaping intact"
+  FAILS=$((FAILS + 1))
+else
+  echo "ok $i - solidus escaping was left intact"
+fi
+
+if ! ../JSON.sh -s < $INPUT| diff -u - ${OUTPUT_WITHOUT_ESCAPING}; then
+  echo "not ok - JSON.sh run with -s option should remove solidus escaping"
+  FAILS=$((FAILS+1))
+else
+  echo "ok $i - solidus escaping has been removed"
+fi
+
+echo "$FAILS test(s) failed"
+exit $FAILS

--- a/test/solidus/string_with_solidus.json
+++ b/test/solidus/string_with_solidus.json
@@ -1,0 +1,1 @@
+"http:\/\/example.com\/article\/1"

--- a/test/solidus/string_with_solidus.no-escaping.parsed
+++ b/test/solidus/string_with_solidus.no-escaping.parsed
@@ -1,0 +1,1 @@
+[]	"http://example.com/article/1"

--- a/test/solidus/string_with_solidus.with-escaping.parsed
+++ b/test/solidus/string_with_solidus.with-escaping.parsed
@@ -1,0 +1,1 @@
+[]	"http:\/\/example.com\/article\/1"


### PR DESCRIPTION
According to http://json.org/, solidus symbol (forward slash) should be escaped as "\/". Some JSON generators abide the rule and generate strings like "http:\/\/example.com\/test".
I've added an option (-s) that provides possibility to normalize such strings and replace "\/" with plain "/".