### PR TITLE
Fixed valid tests number generation on Mac OS X

### DIFF
--- a/test/valid-test.sh
+++ b/test/valid-test.sh
@@ -3,7 +3,8 @@
 cd ${0%/*}
 fails=0
 i=0
-tests=`ls valid/*.json -1l | wc -l`
+tests=`ls -1 valid/*.json | wc -l`
+tests=${tests// /}
 echo "1..$tests"
 for input in valid/*.json
 do


### PR DESCRIPTION
test/valid-test.sh generates valid tests count incorrectly (at least on Mac OS X):

> ./valid-test.sh
ls: -1l: No such file or directory
1..      13
> uname -mrs
Darwin 14.0.0 x86_64