### PR TITLE
Remove non-portable trailing ls options

### DIFF
--- a/test/invalid-test.sh
+++ b/test/invalid-test.sh
@@ -6,7 +6,7 @@ cd ${0%/*}
 # http://en.wikipedia.org/wiki/Test_Anything_Protocol
 
 fails=0
-tests=`ls invalid/* -1 | wc -l`
+tests=`ls invalid/* | wc -l`
 
 echo "1..${tests##* }"
 for input in invalid/*

--- a/test/valid-test.sh
+++ b/test/valid-test.sh
@@ -3,7 +3,7 @@
 cd ${0%/*}
 fails=0
 i=0
-tests=`ls valid/*.json -1l | wc -l`
+tests=`ls valid/*.json | wc -l`
 echo "1..$tests"
 for input in valid/*.json
 do


### PR DESCRIPTION
Trailing options on commands are not portable. Since -1 is the default when used in a pipeline and -l is pointless with wc -l, I just removed them.