### PR TITLE
No head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 test/errlog
 test/outlog
+
+# vi .swp files
+.*.swp

--- a/JSON.sh
+++ b/JSON.sh
@@ -8,6 +8,7 @@ throw () {
 BRIEF=0
 LEAFONLY=0
 PRUNE=0
+NO_HEAD=0
 NORMALIZE_SOLIDUS=0
 
 usage() {
@@ -17,6 +18,7 @@ usage() {
   echo "-p - Prune empty. Exclude fields with empty values."
   echo "-l - Leaf only. Only show leaf nodes, which stops data duplication."
   echo "-b - Brief. Combines 'Leaf only' and 'Prune empty' options."
+  echo "-n - No-head. Do not show nodes that have no path (lines that start with [])."
   echo "-s - Remove escaping of the solidus symbol (stright slash)."
   echo "-h - This help text."
   echo
@@ -38,6 +40,8 @@ parse_options() {
       -l) LEAFONLY=1
       ;;
       -p) PRUNE=1
+      ;;
+      -n) NO_HEAD=1
       ;;
       -s) NORMALIZE_SOLIDUS=1
       ;;
@@ -170,6 +174,8 @@ parse_value () {
        ;;
   esac
   [ "$value" = '' ] && return
+  [ "$NO_HEAD" -eq 1 ] && [ -z "$jpath" ] && return
+
   [ "$LEAFONLY" -eq 0 ] && [ "$PRUNE" -eq 0 ] && print=1
   [ "$LEAFONLY" -eq 1 ] && [ "$isleaf" -eq 1 ] && [ $PRUNE -eq 0 ] && print=1
   [ "$LEAFONLY" -eq 0 ] && [ "$PRUNE" -eq 1 ] && [ "$isempty" -eq 0 ] && print=1
@@ -194,3 +200,5 @@ then
   parse_options "$@"
   tokenize | parse
 fi
+
+# vi: expandtab sw=2 ts=2

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ curl registry.npmjs.org/express | ./JSON.sh | egrep '\["versions","[^"]*"\]'
 -p
 > Prune empty. Exclude fields with empty values.
 
+-n
+> No-head. Don't show nodes that have no path. Normally these output a leading '[]', which you can't use in a bash array.
+
 -s
 > Remove escaping of the solidus symbol (stright slash).
 

--- a/test/no-head-test.sh
+++ b/test/no-head-test.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+
+cd ${0%/*}
+tmp=${TEMP:-/tmp}
+tmp=${tmp%%/}/ # Avoid duplicate //
+
+fails=0
+i=0
+tests=`ls valid/*.json | wc -l`
+echo "1..$tests"
+for input in valid/*.json
+do
+  input_file=${input##*/}
+  expected="${tmp}${input_file%.json}.no-head"
+  egrep -v '^\[]' < ${input%.json}.parsed > $expected
+  i=$((i+1))
+  if ! ../JSON.sh -n < "$input" | diff -u - "$expected" 
+  then
+    echo "not ok $i - $input"
+    fails=$((fails+1))
+  else
+    echo "ok $i - $input"    
+  fi
+done
+echo "$fails test(s) failed"
+exit $fails
+
+# vi: expandtab sw=2 ts=2


### PR DESCRIPTION
Adds a -n "no-head" option.

Normally parsing something like an object will ultimately output a line like

```[]    {blah blah}```

That's something that you can't hand to bash to parse as an array. Obviously you can avoid this with ```-l```, but you might want the intermediate values. 

BTW, I'm working on adding a format option that will make it easier to do things like turn a JSON document into a bash associative array. That feature needs this, but I figured others might find it useful outside of that.