### PR TITLE
Add output format options

### DIFF
--- a/JSON.sh
+++ b/JSON.sh
@@ -35,6 +35,8 @@ parse_format_option() {
     value|value-only) echo value-only ;;
     *) echo "Invalid format specified: $1"
       exit 1
+    # It's important to throw an error here if we were passed an empty argument
+    *) throw "Invalid format '$1' specified. Valid options are array, default, key-only, key-value or value-only."
   esac
 }
 

--- a/JSON.sh
+++ b/JSON.sh
@@ -21,7 +21,7 @@ usage() {
   echo "-p - Prune empty. Exclude fields with empty values."
   echo "-l - Leaf only. Only show leaf nodes, which stops data duplication."
   echo "-b - Brief. Combines 'Leaf only' and 'Prune empty' options."
-  echo "-f - Output format (array (implies -n), default, key-only (implies -n), key-value, value-only or short forms). See README."
+  echo "-f - Output format (array (implies -n), default, key-only (implies -n), key-value (implies -n), value-only or short forms). See README."
   echo "-n - No-head. Do not show nodes that have no path (lines that start with [])."
   echo "-s - Remove escaping of the solidus symbol (stright slash)."
   echo "-h - This help text."
@@ -48,6 +48,7 @@ parse_format_option() {
     kv|key-value)
       FORMAT_STRING="%s\t%s\n"
       FORMAT=key-value
+      NO_HEAD=1
       ;;
     value|value-only)
       FORMAT_STRING= # Set empty as a flag to parse_value()

--- a/JSON.sh
+++ b/JSON.sh
@@ -8,6 +8,7 @@ throw () {
 BRIEF=0
 LEAFONLY=0
 PRUNE=0
+FORCE_NO_HEAD=0
 NO_HEAD=0
 NORMALIZE_SOLIDUS=0
 FORMAT=default
@@ -28,6 +29,7 @@ usage() {
 }
 
 parse_format_option() {
+  NO_HEAD=$FORCE_NO_HEAD
   case $1 in
     a|array)
       FORMAT_STRING="[%s]=%s\n"
@@ -75,7 +77,8 @@ parse_options() {
       ;;
       -p) PRUNE=1
       ;;
-      -n) NO_HEAD=1
+      -n) FORCE_NO_HEAD=1
+          NO_HEAD=1
       ;;
       -s) NORMALIZE_SOLIDUS=1
       ;;

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ By default, parsed values are output in the form
 where ```path``` is the path for the value, ```<tab>``` is a literal tab, and value is the JSON value. That's nice and human-readable, but not always the best for parsing. These additional output formats are available. Note that the -f option will accept the shortest unique name. IE: you can use ```ke``` instead of ```key```, but not just ```k``` because that is ambiguous with the ```key```, ```key-value``` and ```kv``` options.
 
 ### default
-This is the default output format that you get if -f isn't specified.
+This is the default output format that you get if ```-f``` isn't specified.
 
 ### array
 This produces output suitable for loading directly into a bash associative array. It implies -n.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ curl registry.npmjs.org/express | ./JSON.sh | egrep '\["versions","[^"]*"\]'
 -b
 > Brief output. Combines 'Leaf only' and 'Prune empty' options.
 
+-f format
+> Output format. See below.
+
 -l
 > Leaf only. Only show leaf nodes, which stops data duplication.
 
@@ -46,6 +49,45 @@ curl registry.npmjs.org/express | ./JSON.sh | egrep '\["versions","[^"]*"\]'
 
 -h
 > Show help text.
+
+## Format options
+By default, parsed values are output in the form
+
+``` bash
+[path]<tab>value
+```
+
+where ```path``` is the path for the value, ```<tab>``` is a literal tab, and value is the JSON value. That's nice and human-readable, but not always the best for parsing. These additional output formats are available. Note that the -f option will accept the shortest unique name. IE: you can use ```ke``` instead of ```key```, but not just ```k``` because that is ambiguous with the ```key```, ```key-value``` and ```kv``` options.
+
+### default
+This is the default output format that you get if -f isn't specified.
+
+### array
+This produces output suitable for loading directly into a bash associative array. It implies -n.
+
+```bash
+[path]=value
+```
+
+### key
+Output just paths, one per line, without []'s. For example, run against package.json you get:
+
+``` bash
+...
+"bin","JSON.sh"
+"bin"
+...
+```
+
+### key-value (or just kv for short)
+Suitable for processing with the read built-in.
+
+``` bash
+path<tab>value
+```
+
+### value
+Similar to key mode, except you get values one-per-line instead.
 
 ## Cool Links
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ curl registry.npmjs.org/express | ./JSON.sh | egrep '\["versions","[^"]*"\]'
 > Brief output. Combines 'Leaf only' and 'Prune empty' options.
 
 -f format
-> Output format. See below.
+> Output format. See [below](#format-options).
 
 -l
 > Leaf only. Only show leaf nodes, which stops data duplication.

--- a/README.md
+++ b/README.md
@@ -57,19 +57,19 @@ By default, parsed values are output in the form
 [path]<tab>value
 ```
 
-where ```path``` is the path for the value, ```<tab>``` is a literal tab, and value is the JSON value. That's nice and human-readable, but not always the best for parsing. These additional output formats are available. Note that the -f option will accept the shortest unique name. IE: you can use ```ke``` instead of ```key```, but not just ```k``` because that is ambiguous with the ```key```, ```key-value``` and ```kv``` options.
+where ```path``` is the path for the value, ```<tab>``` is a literal tab, and value is the JSON value. That's nice and human-readable, but not always the best for parsing. These additional output formats are available. There are also short-forms available.
 
-### default
+### default (short: d)
 This is the default output format that you get if ```-f``` isn't specified.
 
-### array
+### array (short: a)
 This produces output suitable for loading directly into a bash associative array. It implies -n.
 
 ```bash
 [path]=value
 ```
 
-### key
+### key-only (short: key)
 Output just paths, one per line, without []'s. For example, run against package.json you get:
 
 ``` bash
@@ -79,14 +79,14 @@ Output just paths, one per line, without []'s. For example, run against package.
 ...
 ```
 
-### key-value (or just kv for short)
+### key-value (short: kv)
 Suitable for processing with the read built-in.
 
 ``` bash
 path<tab>value
 ```
 
-### value
+### value-only (short: value)
 Similar to key mode, except you get values one-per-line instead.
 
 ## Cool Links

--- a/all-tests.sh
+++ b/all-tests.sh
@@ -18,13 +18,15 @@ do
     passed=$((passed+1))
   else
     echo FAIL: $test $fail
+    failed="$failed $test"
     fail=$((fail+ret))
   fi
 done
 
 if [ $fail -eq 0 ]; then
-  echo -n 'SUCCESS '
+  echo "SUCCESS $passed / $tests"
 else
-  echo -n 'FAILURE '
+  echo "FAILURE $passed / $tests"
+  echo "Failed tests: $failed"
+  exit 1
 fi
-echo   $passed / $tests

--- a/example.sh
+++ b/example.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+#trap 'echo "$BASH_SOURCE: line $LINENO: returned $?" >&2' ERR
+#set -o errexit -o errtrace -o pipefail
+
+cd ${0%/*}
+. JSON.sh
+
+declare -A Aexec Afunc Akv
+spaces='{ "nested key": {"key with spaces": "value with spaces"}, "tab\tkey":"tab\tvalue", "unnested key": "unnested value","\"qk": "qv\"", "bad": "=\\\"" }'
+spacetoken=`echo $spaces | tokenize`
+
+echo "You can save tokens in a variable"
+tokens=$(tokenize < package.json)
+echo
+echo "But be careful with quoting"
+echo -n '          Raw tokens: ' ; echo $tokens | wc
+echo -n '       Quoted tokens: ' ; echo "$tokens" | wc
+echo -n '   Raw parsed tokens: ' ; echo $tokens | parse | wc
+echo -n 'Quoted parsed tokens: ' ; echo "$tokens" | parse | wc
+echo
+echo "You can change output options on the fly"
+parse_options -f key-only
+keys=$( echo "$tokens" | parse )
+echo 'Keys are:' $keys
+parse_options -f value-only
+echo 'Values are:' $( echo "$tokens" | parse )
+echo
+echo
+echo "Grab a single key-value"
+parse_options -f default
+echo "$tokens" | parse | egrep '^\["repository","url"]'
+echo "Or with key-value output"
+parse_options -f kv
+echo "$tokens" | parse | egrep '^"repository","url"'
+echo "Which you can feed to cut because it's tab delimited and JSON doesn't allow tabs"
+echo "$tokens" | parse | egrep '^"repository","url"' | cut -f2
+echo
+echo
+echo "Key-value mode is really meant for use with read, and is probably the safest way to use JSON.sh"
+lines=0
+echo "$tokens" | parse | {
+  IFS=$'\t'
+  while read -r key value; do
+    ((lines++))
+    [ "$key" == "author" ] && echo Be careful of quoting $key # Won't match!
+    [ "$key" == '"author"' ] && echo Be careful of quoting $value # Note that this can output out of order!
+    [ "$key" == '"repository","url"' ] || continue
+    echo "line $lines: $value"
+    printf 'Or with printf: value=%s\n' "$value"
+  done
+  echo $lines total lines
+}
+echo
+echo "With spaces in key ($spaces)"
+echo Without IFS IS BAD
+echo "$spacetoken" | parse | {
+  while read -r key value; do
+    if echo "$key" | grep -q nest; then
+      echo -n 'BAD!: '
+    else
+      echo -n 'good: '
+    fi
+    echo "'$key' = '$value'"
+  done
+}
+echo With IFS is good
+saveifs=$IFS
+IFS=$'\t'
+while read -r key value; do
+  echo "'$key' = '$value'"
+done < <( echo "$spacetoken" | parse )
+IFS=$saveifs
+echo
+echo "You can also use associative arrays, but it's dangerous. If someone figures out how to bypass quoting their arbitrary value will get eval'ed!"
+eval Aexec=(`./JSON.sh -f array < package.json`)
+parse_options -f array
+eval Afunc=(`cat package.json | tokenize | parse`)
+echo
+[ "${!Aexec[*]}" == "${!Afunc[*]}" ] && echo "Keys match" || echo "Keys don't match!!"
+[ "${Aexec[*]}"  == "${Afunc[*]}"  ] && echo "Values match" || echo "Values don't match!!"
+for key in "${!Afunc[@]}"; do
+  printf '%20s = %s\n' "$key" "${Afunc[$key]}"
+done
+echo
+echo "Need to be careful with array quoting too"
+out=`echo "$spacetoken" | parse`
+echo $out
+eval Afunc=($out)
+echo OK
+for key in "${!Afunc[@]}"; do printf '%40s = %s\n' "$key" "${Afunc[$key]}"; done
+echo bad
+for key in ${!Afunc[@]}; do printf '%40s = %s\n' "$key" "${Afunc[$key]}"; done
+echo bad
+for key in "${!Afunc[*]}"; do printf '%40s = %s\n' "$key" "${Afunc[$key]}"; done
+echo bad
+for key in ${!Afunc[*]}; do printf '%40s = %s\n' "$key" "${Afunc[$key]}"; done
+echo
+echo "You can define an associative array in a read loop, and get similar results without the danger of eval."
+parse_options -f kv
+saveifs=$IFS
+IFS=$'\t'
+while read -r key value; do
+  Akv[$key]=$value
+done < <( echo "$spacetoken" | parse )
+IFS=$saveifs
+parse_options -f array
+eval Afunc=(`echo "$spacetoken" | parse`)
+
+echo Akv:
+for key in "${!Akv[@]}"; do printf '%40s = %s\n' "$key" "${Akv[$key]}"; done
+echo Afunc:
+for key in "${!Afunc[@]}"; do printf '%40s = %s\n' "$key" "${Afunc[$key]}"; done
+
+# vi: expandtab ts=2 sw=2

--- a/test/format-test.sh
+++ b/test/format-test.sh
@@ -29,7 +29,7 @@ done
 runtest() {
   local arg=$1 out
 
-  printf -v out "JSON.sh %q %-${longest_format}s < %q" '-f' "$arg" "$input"
+  printf -v out "${0%/*}/../JSON.sh %q %-${longest_format}s < %q" '-f' "$arg" "${0%/*}/$input"
   i=$((i+1))
   if ! ../JSON.sh -f $arg < "$input" | diff -u - "$expected" 
   then

--- a/test/format-test.sh
+++ b/test/format-test.sh
@@ -1,6 +1,13 @@
 #! /usr/bin/env bash
 
+set -o errexit -o errtrace -o pipefail
+trap 'echo "Error on line ${LINENO}"' ERR
+
 cd ${0%/*}
+
+# NOTE short forms not allowed here.
+formats=(array default key-only key-value value-only)
+declare -A short_formats=([array]=a [default]=d [key-only]=key [key-value]=kv [value-only]=value)
 
 tmp=${TEMP:-/tmp}
 tmp=${tmp%/}/ # Avoid double //
@@ -9,40 +16,77 @@ fails=0
 i=0
 tab=$'\t'
 tests=`ls valid/*.json | wc -l`
-tests=$[tests*2]
+tests=$[tests*${#formats[*]}*2] # *2 for short formats.
 echo "1..$tests"
+
+# Figure out longest format length just once
+longest_format=0
+for format in ${formats[@]}
+do
+  [ ${#format} -gt $longest_format ] && longest_format=${#format}
+done
+
+runtest() {
+  local arg=$1 out
+
+  printf -v out "JSON.sh %q %-${longest_format}s < %q" '-f' "$arg" "$input"
+  i=$((i+1))
+  if ! ../JSON.sh -f $arg < "$input" | diff -u - "$expected" 
+  then
+    echo "not ok $i - $out"
+    fails=$((fails+1))
+    return 1
+  else
+    echo "ok $i - $out"
+  fi
+}
 
 for input in valid/*.json
 do
   input_file=${input##*/}
-  for format in a k
+  parsed=${input%.json}.parsed
+
+  for format in ${formats[@]}
   do
-    expected=$tmp${input_file%.json}
+    expected=$tmp${input_file%.json}.$format
     case $format in
-      a)
-        expected=${expected}.array
-        cat ${input%.json}.parsed | tr '\t' = > $expected
+      array)
+        cat $parsed | tr '\t' = > $expected
         ;;
-      k)
-        expected=${expected}.keyvalue
+      default)
+        cp $parsed $expected
+        ;;
+      key-only)
         # Pattern matches '^[<not ]]' and extracts the part in the []
-        cat ${input%.json}.parsed | sed -e 's/^\[//' -e "s/]$tab/$tab/" > $expected
+        cat $parsed | sed -e 's/^\[//' -e "s/]$tab/$tab/" | cut -f 1 > $expected
+        ;;
+      key-value)
+        # Pattern matches '^[<not ]]' and extracts the part in the []
+        cat $parsed | sed -e 's/^\[//' -e "s/]$tab/$tab/" > $expected
+        ;;
+      value-only)
+        # Pattern matches '^[<not ]]' and extracts the part in the []
+        cat $parsed | sed -e 's/^\[//' -e "s/]$tab/$tab/" | cut -f 2 > $expected
         ;;
       *)
         echo "Unknown format option $format"
         exit 1
     esac
 
-    i=$((i+1))
-    if ! ../JSON.sh -f $format < "$input" | diff -u - "$expected" 
-    then
-      echo "not ok $i - $input"
-      fails=$((fails+1))
-    else
-      echo "ok $i - $input"    
-    fi
+    bothpass=0
+    runtest $format && bothpass=1
+
+    # Just blow up if we don't have a valid short format
+    [ -n "${short_formats[$format]}" ] || ( echo "Tests definition error: no short format for '$format'."; exit 1 )
+    runtest ${short_formats[$format]} && [ $bothpass -eq 1 ] && rm $expected
   done
 done
+
+if [ $i -ne $tests ]; then
+  echo "Count of tests run ($i) does not match expected test count ($tests)"
+  exit 1
+fi
+
 echo "$fails test(s) failed"
 exit $fails
 

--- a/test/format-test.sh
+++ b/test/format-test.sh
@@ -1,0 +1,49 @@
+#! /usr/bin/env bash
+
+cd ${0%/*}
+
+tmp=${TEMP:-/tmp}
+tmp=${tmp%/}/ # Avoid double //
+
+fails=0
+i=0
+tab=$'\t'
+tests=`ls valid/*.json | wc -l`
+tests=$[tests*2]
+echo "1..$tests"
+
+for input in valid/*.json
+do
+  input_file=${input##*/}
+  for format in a k
+  do
+    expected=$tmp${input_file%.json}
+    case $format in
+      a)
+        expected=${expected}.array
+        cat ${input%.json}.parsed | tr '\t' = > $expected
+        ;;
+      k)
+        expected=${expected}.keyvalue
+        # Pattern matches '^[<not ]]' and extracts the part in the []
+        cat ${input%.json}.parsed | sed -e 's/^\[//' -e "s/]$tab/$tab/" > $expected
+        ;;
+      *)
+        echo "Unknown format option $format"
+        exit 1
+    esac
+
+    i=$((i+1))
+    if ! ../JSON.sh -f $format < "$input" | diff -u - "$expected" 
+    then
+      echo "not ok $i - $input"
+      fails=$((fails+1))
+    else
+      echo "ok $i - $input"    
+    fi
+  done
+done
+echo "$fails test(s) failed"
+exit $fails
+
+# vi: expandtab sw=2 ts=2

--- a/test/format-test.sh
+++ b/test/format-test.sh
@@ -75,7 +75,7 @@ do
         ;;
       value-only)
         # Pattern matches '^[<not ]]' and extracts the part in the []
-        cat $parsed | sed -e 's/^\[//' -e "s/]$tab/$tab/" | cut -f 2 | safegrep -E -v '^$' > $expected
+        cat $parsed | sed -e 's/^\[//' -e "s/]$tab/$tab/" | cut -f 2 > $expected
         ;;
       *)
         echo "$0: Unknown format option '$format'"

--- a/test/format-test.sh
+++ b/test/format-test.sh
@@ -49,7 +49,7 @@ do
   for format in ${formats[@]}
   do
     expected=$tmp${input_file%.json}.$format
-    case $format in
+    case "$format" in
       array)
         cat $parsed | tr '\t' = > $expected
         ;;

--- a/test/format-test.sh
+++ b/test/format-test.sh
@@ -69,7 +69,7 @@ do
         cat $parsed | sed -e 's/^\[//' -e "s/]$tab/$tab/" | cut -f 2 > $expected
         ;;
       *)
-        echo "Unknown format option $format"
+        echo "$0: Unknown format option '$format'"
         exit 1
     esac
 

--- a/test/format-test.sh
+++ b/test/format-test.sh
@@ -71,7 +71,7 @@ do
         ;;
       key-value)
         # Pattern matches '^[<not ]]' and extracts the part in the []
-        cat $parsed | sed -e 's/^\[//' -e "s/]$tab/$tab/" > $expected
+        cat $parsed | safegrep -E -v '^\[]' | sed -e 's/^\[//' -e "s/]$tab/$tab/" > $expected
         ;;
       value-only)
         # Pattern matches '^[<not ]]' and extracts the part in the []

--- a/test/format-test.sh
+++ b/test/format-test.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
+trap 'echo "$BASH_SOURCE: line $LINENO" >&2' ERR
 set -o errexit -o errtrace -o pipefail
-trap 'echo "Error on line ${LINENO}"' ERR
 
 cd ${0%/*}
 


### PR DESCRIPTION
This is an attempt to make it easier to parse JSON.sh output from within bash.

The first thing I looked at was supporting direct assignment to associative arrays (declare -A, not declare -a), since the native output format is very close to what you need for that. That change essentially amounts to piping the original output through `egrep -v '^\[]' | tr '\t' =`.

Despite the usefulness of that, I'm not a fan of it because as far as I can tell the only way to actually interpret that in bash is by using an eval, which is dangerous. If someone finds a flaw in any of this they could potentially inject any arbitrary code, which would then get eval'd. I'll leave it to the reader to figure out what something like `eval rm -rf /`` would end up doing...

The next thing I looked at was better support for `read -r key value`. Thanks to the tab delimiter, that was also pretty easy: I just stripped the `[]` surrounding the path. This seems pretty robust, so long as you change IFS to `$'\t'`. That works because tabs aren't valid in JSON, and the script seems to detect that pretty robustly (though I didn't exhaustively test that).

The part I don't like about key-value mode is everything stays wrapped in double-quotes. Probably not a big deal for keys (I guess), but I'm worried it might cause problems for values. Especially values that have escapes in them. Maybe there's a clean way to deal with that.

The remaining 3 modes are simple... key-only and value-only produce one key or value per line, as you'd expect. The default mode retains the same behavior as today.

I also added a script of examples. It's a bit verbose and ugly, but at least it gives a good foundation on using the script. It does lean very heavily towards the function interface though, which is probably not a good thing to promote since JSON.sh makes heavy use of globals.
