### PR TITLE
Support ash/dash/zsh shells, support systems without bash (busybox), add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+
+addons:
+  apt:
+    packages:
+      - bash
+      - dash
+      - zsh
+
+# Whatever the current shebang, replace with hardcoded shell
+script: >
+  sed -i '1s@.*@#!/usr/bin/env bash@' JSON.sh && ./all-tests.sh &&
+  sed -i '1s@.*@#!/usr/bin/env zsh@'  JSON.sh && ./all-tests.sh &&
+  sed -i '1s@.*@#!/usr/bin/env dash@' JSON.sh && ./all-tests.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSON.sh
 
-yo, so it's a json parser written in bash
+yo, so it's a json parser written in shell, compatible with ash, bash, dash and zsh
 
 pipe json to it, and it traverses the json objects and prints out the 
 path to the current object (as a JSON array) and then the object, without whitespace.

--- a/all-tests.sh
+++ b/all-tests.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/bin/sh
 
 cd ${0%/*}
 
@@ -12,7 +12,7 @@ do
   tests=$((tests+1))
   echo TEST: $test
   ./$test
-  ret=$? 
+  ret=$?
   if [ $ret -eq 0 ] ; then
     echo OK: ---- $test
     passed=$((passed+1))
@@ -24,7 +24,10 @@ done
 
 if [ $fail -eq 0 ]; then
   echo -n 'SUCCESS '
+  exitcode=0
 else
   echo -n 'FAILURE '
+  exitcode=1
 fi
 echo   $passed / $tests
+exit $exitcode

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "JSON.sh",
   "version": "0.3.1",
-  "description": "JSON parser written in bash",
+  "description": "JSON parser written in shell",
   "homepage": "http://github.com/dominictarr/JSON.sh",
   "repository": {
     "type": "git",

--- a/test/invalid-test.sh
+++ b/test/invalid-test.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/bin/sh
 
 cd ${0%/*}
 

--- a/test/no-head-test.sh
+++ b/test/no-head-test.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/bin/sh
 
 cd ${0%/*}
 tmp=${TEMP:-/tmp}

--- a/test/parse-test.sh
+++ b/test/parse-test.sh
@@ -1,8 +1,9 @@
-#! /usr/bin/env bash
+#!/bin/sh
 
 cd ${0%/*}
 
-. ../JSON.sh
+# Can't detect sourcing in sh, so immediately terminate the attempt to parse
+. ../JSON.sh </dev/null
 
 ptest () {
   tokenize | parse >/dev/null

--- a/test/solidus-test.sh
+++ b/test/solidus-test.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/bin/sh
 
 cd ${0%/*}
 

--- a/test/tokenizer-test.sh
+++ b/test/tokenizer-test.sh
@@ -1,7 +1,9 @@
-#! /usr/bin/env bash
+#!/bin/sh
 
 cd ${0%/*}
-. ../JSON.sh
+
+# Can't detect sourcing in sh, so immediately terminate the attempt to parse
+. ../JSON.sh </dev/null
 
 i=0
 fails=0

--- a/test/valid-test.sh
+++ b/test/valid-test.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/bin/sh
 
 cd ${0%/*}
 fails=0


### PR DESCRIPTION
Lots of stuff in here, including a fix to allow testing of tokenize and parse with posix shells (which I didn't manage to figure out before).

Before merging you'll need to enable travis for this repo, then close and open this PR. That should trigger a build in travis to prove it all works, as demonstrated at https://github.com/aidanhs/JSON.sh/pull/1.

The changing of all the shebang lines is to support busybox which I manually tested.

@zaa sed is now required for solidus escaping, but it works in busybox (and sed seems like it would go hand-in-hand with grep which is required anyway). Hopefully this isn't an issue?