### PR TITLE
Slim down npm tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-test/errlog
-test/outlog
+/test/errlog
+/test/outlog
 
 # vi .swp files
 .*.swp
+
+/JSON.sh-*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "JSON.sh",
+  "version": "0.3.3",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "bin": {
     "JSON.sh": "./JSON.sh"
   },
+  "files": [
+    "JSON.sh"
+  ],
   "dependencies": {},
   "devDependencies": {},
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://bit.ly/dominictarr)",


### PR DESCRIPTION
Only the JSON.sh script is necessary in the npm tarball.
Tests and other files shouldn't be packaged.

(Also, ignore the tarball itself if npm-pack is ever run.)