### PR TITLE
tweak testing suite for small bugs

### DIFF
--- a/all-tests.sh
+++ b/all-tests.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-cd ${0%/*}
+cd "${0%/*}"
 
 #set -e
 fail=0
 tests=0
+passed=0
 #all_tests=${__dirname:}
 #echo PLAN ${#all_tests}
 for test in test/*.sh ;
@@ -23,11 +24,11 @@ do
 done
 
 if [ $fail -eq 0 ]; then
-  echo -n 'SUCCESS '
+  /bin/echo -n 'SUCCESS '
   exitcode=0
 else
-  echo -n 'FAILURE '
+  /bin/echo -n 'FAILURE '
   exitcode=1
 fi
-echo   $passed / $tests
+echo $passed / $tests
 exit $exitcode


### PR DESCRIPTION
Thanks for this - years later and it's still solid.

Because this seems to be used as a template for a 'simple shell testing suite' in other projects, I thought I'd submit the following minor corrections. Even if it doesn't matter for this project it will cover when people copy-paste this code into their own projects.

- cd with quotes for the directory chain with whitespace
- shows '0' when passed = 0
- built in `echo` for `sh` doesn't have `-n` option on some distributions, so use the more reliable /bin/echo in places where we need `-n`.